### PR TITLE
Unify the context structure.

### DIFF
--- a/src/rules/__tests__/getExtensionSettingsByRuleComponent.test.js
+++ b/src/rules/__tests__/getExtensionSettingsByRuleComponent.test.js
@@ -12,6 +12,25 @@ governing permissions and limitations under the License.
 const getExtensionSettingsByRuleComponent = require('../getExtensionSettingsByRuleComponent');
 
 describe('getExtensionSettingsByRuleComponent', () => {
+  test('calls getExtensionSettings with the full context data', () => {
+    const arcAndUtils = { arc: { contextData1: 2 }, utils: {} };
+    const extensionSettingsMockFn = jest.fn(() => Promise.resolve());
+
+    return getExtensionSettingsByRuleComponent({
+      delegateConfig: {
+        extension: {
+          getExtensionSettings: extensionSettingsMockFn
+        }
+      },
+      arcAndUtils
+    }).then(() => {
+      expect(extensionSettingsMockFn).toHaveBeenCalledWith({
+        arcAndUtils: { arc: { contextData1: 2 }, utils: {} },
+        delegateConfig: { extension: expect.any(Object) }
+      });
+    });
+  });
+
   test('adds the extension settings to the context data', () => {
     const extensionSettings = { setting1: 1 };
     const arcAndUtils = { arc: { contextData1: 2 }, utils: {} };

--- a/src/rules/getExtensionSettingsByRuleComponent.js
+++ b/src/rules/getExtensionSettingsByRuleComponent.js
@@ -9,7 +9,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-module.exports = ({ arcAndUtils, delegateConfig }) => {
+module.exports = (context) => {
+  const { arcAndUtils, delegateConfig } = context;
   const { utils } = arcAndUtils;
   let {
     extension: { getExtensionSettings }
@@ -19,7 +20,7 @@ module.exports = ({ arcAndUtils, delegateConfig }) => {
     getExtensionSettings = () => Promise.resolve({});
   }
 
-  return getExtensionSettings(arcAndUtils).then((extensionSettings) => ({
+  return getExtensionSettings(context).then((extensionSettings) => ({
     arcAndUtils: {
       ...arcAndUtils,
       utils: {


### PR DESCRIPTION
The getDataElementValue function was receiving a different context structure when it was called from the get extension settings function.

## Description

When getDataElementValue function was called from a rule, the context was having the structure: `{ arcAndUtils: { arc: {...}, utils: {...}}, delegateConfig: {...} }`.

When getDataElementValue function was called when the extension settings were accessed, the context was having the structure: `{ arc: {...}, utils: {...} }`.

This mismatch was throwing an error.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have made any necessary test changes and all tests pass.
