### PR TITLE
PDCL-6352 Fix the modules chains so that logs are accurate.

### DIFF
--- a/src/__mocks__/containerInitFunction.js
+++ b/src/__mocks__/containerInitFunction.js
@@ -75,9 +75,11 @@ module.exports = (getDataElementValues) => ({
   rules: [
     {
       id: 'RLbb1d94c79fee4733a510564a86ba3c59',
-      name: 'Rule 1',
+      name: 'Rule with one condition and two actions',
       conditions: [
         {
+          id: 'RCbb1d94c79fee4733a510564a86ba3c99',
+          name: 'Custom Code',
           modulePath: 'core/src/lib/conditions/customCode.js',
           timeout: 100,
           getSettings: () =>
@@ -88,6 +90,8 @@ module.exports = (getDataElementValues) => ({
       ],
       actions: [
         {
+          id: 'RCbb1d94c79fee4733a510564a86ba3a99',
+          name: 'Send Data',
           modulePath: 'adobe-cloud-connector/src/lib/actions/sendData.js',
           timeout: 100,
           getSettings: (context) =>
@@ -102,6 +106,8 @@ module.exports = (getDataElementValues) => ({
             )
         },
         {
+          id: 'RCbb1d94c79fee4733a510564a86ba3a99',
+          name: 'Send Data',
           modulePath: 'extension-with-settings/src/lib/actions/sendData.js',
           timeout: 100,
           getSettings: (context) => {
@@ -112,9 +118,11 @@ module.exports = (getDataElementValues) => ({
     },
     {
       id: 'RLbb1d94c79fee4733a510564a86ba3c60',
-      name: 'Rule 2',
+      name: 'Rule with one action',
       actions: [
         {
+          id: 'RCbb1d94c79fee4733a510564a86ba3a99',
+          name: 'Send Data',
           modulePath: 'adobe-cloud-connector/src/lib/actions/sendData.js',
           timeout: 100,
           getSettings: () =>
@@ -122,6 +130,49 @@ module.exports = (getDataElementValues) => ({
               method: 'GET',
               url: 'https://webhook.site/160e3622-264a-4d9b-aeb4-875d9a3f3a5a'
             })
+        }
+      ]
+    },
+    {
+      id: 'RLbb1d94c79fee4733a510564a86ba3c99',
+      name: 'Rule with one false condition and two actions',
+      conditions: [
+        {
+          id: 'RCbb1d94c79fee4733a510564a86ba3c99',
+          name: 'Custom Code',
+          modulePath: 'core/src/lib/conditions/customCode.js',
+          timeout: 100,
+          getSettings: () =>
+            Promise.resolve({
+              source: () => false
+            })
+        }
+      ],
+      actions: [
+        {
+          id: 'RCbb1d94c79fee4733a510564a86ba3a99',
+          name: 'Send Data',
+          modulePath: 'adobe-cloud-connector/src/lib/actions/sendData.js',
+          timeout: 100,
+          getSettings: (context) =>
+            getDataElementValues(['myPrecious'], context).then(
+              (getDataElementValue) => ({
+                method: 'POST',
+                body: '',
+                url: `https://webhook.site/160e3622-264a-4d9b-aeb4-875d9a3f3a5a?z=${getDataElementValue(
+                  'myPrecious'
+                )}`
+              })
+            )
+        },
+        {
+          id: 'RCbb1d94c79fee4733a510764a86ba3c99',
+          name: 'Send Data',
+          modulePath: 'extension-with-settings/src/lib/actions/sendData.js',
+          timeout: 100,
+          getSettings: (context) => {
+            return getDataElementValues([], context).then(() => ({}));
+          }
         }
       ]
     }

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -44,25 +44,31 @@ describe('index', () => {
           ruleId: 'RLbb1d94c79fee4733a510564a86ba3c59',
           status: 'success',
           logs: [
-            ['Rule "Rule 1" is being executed.'],
+            [
+              'Execution of rule "Rule with one condition and two actions" is starting.',
+              'log'
+            ],
             [
               'Calling "Custom Code Condition" module from the "Core" extension.',
               'Event: ',
               '{"xdm":{},"data":{}}',
               'Rule Stash: ',
-              '{}'
+              '{}',
+              'log'
             ],
             [
               '"Custom Code Condition" module from the "Core" extension returned.',
               'Output:',
-              'true'
+              'true',
+              'log'
             ],
             [
               'Calling "Send Beacon" module from the "Adobe Cloud Connector" extension.',
               'Event: ',
               '{"xdm":{},"data":{}}',
               'Rule Stash: ',
-              '{}'
+              '{}',
+              'log'
             ],
             [
               'FETCH',
@@ -73,24 +79,32 @@ describe('index', () => {
               'Response Status',
               '200',
               'Response Body',
-              'empty'
+              'empty',
+              'log'
             ],
             [
               '"Send Beacon" module from the "Adobe Cloud Connector" extension returned.',
               'Output:',
-              'send data done'
+              'send data done',
+              'log'
             ],
             [
               'Calling "Send Beacon" module from the "Demo Extensions With Settings" extension.',
               'Event: ',
               '{"xdm":{},"data":{}}',
               'Rule Stash: ',
-              '{"adobe-cloud-connector":"send data done"}'
+              '{"adobe-cloud-connector":"send data done"}',
+              'log'
             ],
             [
               '"Send Beacon" module from the "Demo Extensions With Settings" extension returned.',
               'Output:',
-              'UA-X-123'
+              'UA-X-123',
+              'log'
+            ],
+            [
+              'Execution of rule "Rule with one condition and two actions" is complete.',
+              'log'
             ]
           ]
         },
@@ -98,13 +112,14 @@ describe('index', () => {
           ruleId: 'RLbb1d94c79fee4733a510564a86ba3c60',
           status: 'success',
           logs: [
-            ['Rule "Rule 2" is being executed.'],
+            ['Execution of rule "Rule with one action" is starting.', 'log'],
             [
               'Calling "Send Beacon" module from the "Adobe Cloud Connector" extension.',
               'Event: ',
               '{"xdm":{},"data":{}}',
               'Rule Stash: ',
-              '{}'
+              '{}',
+              'log'
             ],
             [
               'FETCH',
@@ -115,14 +130,50 @@ describe('index', () => {
               'Response Status',
               '200',
               'Response Body',
-              'empty'
+              'empty',
+              'log'
             ],
             [
               '"Send Beacon" module from the "Adobe Cloud Connector" extension returned.',
               'Output:',
-              'send data done'
-            ]
+              'send data done',
+              'log'
+            ],
+            ['Execution of rule "Rule with one action" is complete.', 'log']
           ]
+        },
+        {
+          logs: [
+            [
+              'Execution of rule "Rule with one false condition and two actions" is starting.',
+              'log'
+            ],
+            [
+              'Calling "Custom Code Condition" module from the "Core" extension.',
+              'Event: ',
+              '{"xdm":{},"data":{}}',
+              'Rule Stash: ',
+              '{}',
+              'log'
+            ],
+            [
+              '"Custom Code Condition" module from the "Core" extension returned.',
+              'Output:',
+              'false',
+              'log'
+            ],
+            [
+              'Failed to execute "Custom Code Condition". Condition "Custom Code Condition" ' +
+                'from rule "Rule with one false condition and two actions" not met.',
+              'log'
+            ],
+            [
+              'Execution of rule "Rule with one false condition and two actions" is complete.',
+              'log'
+            ]
+          ],
+          ruleId: 'RLbb1d94c79fee4733a510564a86ba3c99',
+          status: 'condition_not_met'
         }
       ]);
     });

--- a/src/rules/__mocks__/addModuleToQueue.js
+++ b/src/rules/__mocks__/addModuleToQueue.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Adobe. All rights reserved.
+Copyright 2021 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -9,20 +9,5 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const process = (logsBucket, type, args) => {
-  logsBucket.push(
-    args
-      .map((m) => (typeof m !== 'string' ? JSON.stringify(m) : m))
-      .concat(type)
-  );
-};
-
-module.exports = () => {
-  const logsBucket = [];
-
-  return {
-    log: (...args) => process(logsBucket, 'log', args),
-    error: (...args) => process(logsBucket, 'error', args),
-    getJsonLogs: () => logsBucket
-  };
-};
+module.exports = (lastPromiseInChain, resultFn, delegateConfig) =>
+  lastPromiseInChain.then(() => Promise.resolve(resultFn(delegateConfig)));

--- a/src/rules/__mocks__/logModuleErrorAndRethrow.js
+++ b/src/rules/__mocks__/logModuleErrorAndRethrow.js
@@ -9,4 +9,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-module.exports = () => (e) => Promise.reject(e);
+module.exports = () => (e) => {
+  e.message = `enhanced error: ${e.message}`;
+  return Promise.reject(e);
+};

--- a/src/rules/__mocks__/normalizeDelegate.js
+++ b/src/rules/__mocks__/normalizeDelegate.js
@@ -9,20 +9,4 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const process = (logsBucket, type, args) => {
-  logsBucket.push(
-    args
-      .map((m) => (typeof m !== 'string' ? JSON.stringify(m) : m))
-      .concat(type)
-  );
-};
-
-module.exports = () => {
-  const logsBucket = [];
-
-  return {
-    log: (...args) => process(logsBucket, 'log', args),
-    error: (...args) => process(logsBucket, 'error', args),
-    getJsonLogs: () => logsBucket
-  };
-};
+module.exports = (e) => e;

--- a/src/rules/__tests__/addModuleToQueue.test.js
+++ b/src/rules/__tests__/addModuleToQueue.test.js
@@ -14,10 +14,8 @@ const getExecuteModulePromise = require('../getExecuteModulePromise.js');
 
 jest.mock('../getExecuteModulePromise.js');
 jest.mock('../enhanceExecutionErrorMessageAndRethrow.js');
-jest.mock('../logModuleErrorAndRethrow.js');
 jest.mock('../transformToTimeBoundedPromise.js');
 
-const utils = {};
 const delegateConfig = {};
 
 describe('addModuleToQueue', () => {
@@ -29,8 +27,7 @@ describe('addModuleToQueue', () => {
     return addModuleToQueue(
       Promise.resolve(),
       processResultFn,
-      delegateConfig,
-      utils
+      delegateConfig
     ).then(() => {
       expect(processResultFn).toHaveBeenCalledWith('module result');
     });
@@ -43,12 +40,7 @@ describe('addModuleToQueue', () => {
       throw new Error('error from inside the module');
     });
 
-    return addModuleToQueue(
-      Promise.resolve(),
-      processResultFn,
-      delegateConfig,
-      utils
-    )
+    return addModuleToQueue(Promise.resolve(), processResultFn, delegateConfig)
       .then(() => {
         throw new Error('This section should not have been called.');
       })
@@ -64,12 +56,7 @@ describe('addModuleToQueue', () => {
 
     getExecuteModulePromise.mockResolvedValue('module result');
 
-    return addModuleToQueue(
-      Promise.resolve(),
-      processResultFn,
-      delegateConfig,
-      utils
-    )
+    return addModuleToQueue(Promise.resolve(), processResultFn, delegateConfig)
       .then(() => {
         throw new Error('This section should not have been called.');
       })

--- a/src/rules/__tests__/checkConditionResult.test.js
+++ b/src/rules/__tests__/checkConditionResult.test.js
@@ -10,6 +10,7 @@ governing permissions and limitations under the License.
 */
 
 const checkConditionResult = require('../checkConditionResult');
+const ConditionNotMetError = require('../conditionNotMetError');
 
 describe('checkConditionResult', () => {
   test('returns a resolved promise in chain when condition result is true', () => {
@@ -96,6 +97,7 @@ describe('checkConditionResult', () => {
         throw new Error('This section should not have been called.');
       })
       .catch((e) => {
+        expect(e).toBeInstanceOf(ConditionNotMetError);
         expect(e.message).toBe('Condition "A" from rule "R" not met.');
       });
   });

--- a/src/rules/__tests__/createPromiseChain.test.js
+++ b/src/rules/__tests__/createPromiseChain.test.js
@@ -1,0 +1,72 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const createPromiseChain = require('../createPromiseChain');
+
+jest.mock('../logModuleErrorAndRethrow.js');
+jest.mock('../normalizeDelegate.js');
+jest.mock('../addModuleToQueue.js');
+
+const context = { someProperty: 'some_value' };
+const modules = [
+  {
+    modulePath: 'core/src/lib/conditions/customCode1.js',
+    settings: {
+      a: 'a'
+    }
+  },
+  {
+    modulePath: 'core/src/lib/conditions/customCode2.js',
+    settings: {
+      b: 'b'
+    }
+  }
+];
+
+describe('createPromiseChain', () => {
+  test('adds each module to the promise chain', () => {
+    const moduleList = [];
+    const resultFn = (delegateConfig) => {
+      moduleList.push(delegateConfig.modulePath);
+    };
+
+    return createPromiseChain({
+      modules,
+      resultFn
+    })(context).then(() => {
+      expect(moduleList).toEqual([
+        'core/src/lib/conditions/customCode1.js',
+        'core/src/lib/conditions/customCode2.js'
+      ]);
+    });
+  });
+
+  test('returns the initial context if no modules are provided', () => {
+    return createPromiseChain({
+      modules: []
+    })(context).then((c) => {
+      expect(c).toEqual({ someProperty: 'some_value' });
+    });
+  });
+
+  test('cathces error thrown by the module', () => {
+    const resultFn = () => {
+      throw new Error('some error');
+    };
+
+    return createPromiseChain({
+      modules,
+      resultFn
+    })(context).catch((e) => {
+      expect(e.message).toBe('enhanced error: some error');
+    });
+  });
+});

--- a/src/rules/__tests__/logDelegateModuleCall.test.js
+++ b/src/rules/__tests__/logDelegateModuleCall.test.js
@@ -33,7 +33,8 @@ describe('logDelegateModuleCall', () => {
         'Event: ',
         '{"c":1}',
         'Rule Stash: ',
-        '{"d":2}'
+        '{"d":2}',
+        'log'
       ]
     ]);
     expect(result).toBe(context);

--- a/src/rules/__tests__/logModuleErrorAndRethrow.test.js
+++ b/src/rules/__tests__/logModuleErrorAndRethrow.test.js
@@ -11,9 +11,10 @@ governing permissions and limitations under the License.
 
 const logModuleErrorAndRethrow = require('../logModuleErrorAndRethrow');
 const createNewLogger = require('../../__mocks__/createNewLogger');
+const ConditionNotMetError = require('../conditionNotMetError');
 
 describe('logModuleErrorAndRethrow', () => {
-  test('logs the error with a stack when available and returs a rejected promise', () => {
+  test('logs the error message with a stack when available and returs a rejected promise', () => {
     const logger = createNewLogger();
     const e = new Error('some error');
 
@@ -21,8 +22,19 @@ describe('logModuleErrorAndRethrow', () => {
       .then(() => {})
       .catch(() => {
         expect(logger.getJsonLogs()).toStrictEqual([
-          [`some error \n ${e.stack}`]
+          [`some error \n ${e.stack}`, 'error']
         ]);
+      });
+  });
+
+  test('logs the log message for a ConditionNotMetError and returs a rejected promise', () => {
+    const logger = createNewLogger();
+    const e = new ConditionNotMetError('some error');
+
+    logModuleErrorAndRethrow({ utils: { logger } })(e)
+      .then(() => {})
+      .catch(() => {
+        expect(logger.getJsonLogs()).toStrictEqual([['some error', 'log']]);
       });
   });
 
@@ -33,7 +45,7 @@ describe('logModuleErrorAndRethrow', () => {
     logModuleErrorAndRethrow({ utils: { logger } })(e)
       .then(() => {})
       .catch(() => {
-        expect(logger.getJsonLogs()).toStrictEqual([['some error']]);
+        expect(logger.getJsonLogs()).toStrictEqual([['some error', 'error']]);
       });
   });
 });

--- a/src/rules/__tests__/logRuleEnding.test.js
+++ b/src/rules/__tests__/logRuleEnding.test.js
@@ -9,29 +9,26 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const logDelegateModuleOutput = require('../logDelegateModuleOutput');
+const logRuleEnding = require('../logRuleEnding');
 const createNewLogger = require('../../__mocks__/createNewLogger');
 
-describe('logDelegateModuleOutput', () => {
-  test('logs the call to and returns the context', () => {
+describe('logRuleEnding', () => {
+  test('logs the call to and returns the contextData', () => {
     const logger = createNewLogger();
+
     const context = {
-      moduleOutput: 'module output',
-      arcAndUtils: { arc: { c: 1 }, utils: { logger } },
-      delegateConfig: {
-        displayName: 'module display name',
-        extension: { displayName: 'extension display name' }
+      arcAndUtils: {
+        arc: { c: 1 },
+        utils: {
+          getRule: () => ({ name: 'rule name' }),
+          logger
+        }
       }
     };
 
-    const result = logDelegateModuleOutput(context);
-    expect(result.arcAndUtils.utils.logger.getJsonLogs()).toStrictEqual([
-      [
-        '"module display name" module from the "extension display name" extension returned.',
-        'Output:',
-        'module output',
-        'log'
-      ]
+    const result = logRuleEnding(context);
+    expect(logger.getJsonLogs()).toStrictEqual([
+      ['Execution of rule "rule name" is complete.', 'log']
     ]);
     expect(result).toBe(context);
   });

--- a/src/rules/__tests__/logRuleStarting.test.js
+++ b/src/rules/__tests__/logRuleStarting.test.js
@@ -28,7 +28,7 @@ describe('logRuleStarting', () => {
 
     const result = logRuleStarting(context);
     expect(logger.getJsonLogs()).toStrictEqual([
-      ['Rule "rule name" is being executed.']
+      ['Execution of rule "rule name" is starting.', 'log']
     ]);
     expect(result).toBe(context);
   });

--- a/src/rules/__tests__/returnRuleResult.test.js
+++ b/src/rules/__tests__/returnRuleResult.test.js
@@ -10,6 +10,7 @@ governing permissions and limitations under the License.
 */
 
 const returnRuleResult = require('../returnRuleResult');
+const ConditionNotMetError = require('../conditionNotMetError');
 
 describe('returnRuleResult', () => {
   test('returns the result for a successful rule', () => {
@@ -35,6 +36,22 @@ describe('returnRuleResult', () => {
         expect(ruleResult).toStrictEqual({
           ruleId: 123,
           status: 'failed',
+          logs: [{ a: 1 }, { b: 2 }]
+        })
+    );
+  });
+
+  test('returns the result for a rule with a condition that is not met', () => {
+    const lastPromiseInQueue = Promise.reject(
+      new ConditionNotMetError('Condition not met')
+    );
+    const logger = { getJsonLogs: () => [{ a: 1 }, { b: 2 }] };
+
+    return returnRuleResult(lastPromiseInQueue, { id: 123 }, logger).then(
+      (ruleResult) =>
+        expect(ruleResult).toStrictEqual({
+          ruleId: 123,
+          status: 'condition_not_met',
           logs: [{ a: 1 }, { b: 2 }]
         })
     );

--- a/src/rules/addModuleToQueue.js
+++ b/src/rules/addModuleToQueue.js
@@ -12,22 +12,14 @@ governing permissions and limitations under the License.
 const transformToTimeBoundedPromise = require('./transformToTimeBoundedPromise');
 const getExecuteModulePromise = require('./getExecuteModulePromise');
 const enhanceExecutionErrorMessageAndRethrow = require('./enhanceExecutionErrorMessageAndRethrow');
-const logModuleErrorAndRethrow = require('./logModuleErrorAndRethrow');
 
-module.exports = (
-  lastPromiseInQueue,
-  processModuleResultFn,
-  delegateConfig,
-  utils
-) =>
-  lastPromiseInQueue
-    .then((context) =>
-      Promise.resolve({
-        ...context,
-        delegateConfig
-      })
-    )
-    .then(transformToTimeBoundedPromise(getExecuteModulePromise))
-    .catch(enhanceExecutionErrorMessageAndRethrow({ delegateConfig }))
-    .then(processModuleResultFn)
-    .catch(logModuleErrorAndRethrow({ utils }));
+module.exports = (lastPromiseInQueue, processModuleResultFn, delegateConfig) =>
+  lastPromiseInQueue.then((context) =>
+    Promise.resolve({
+      ...context,
+      delegateConfig
+    })
+      .then(transformToTimeBoundedPromise(getExecuteModulePromise))
+      .then(processModuleResultFn)
+      .catch(enhanceExecutionErrorMessageAndRethrow({ delegateConfig }))
+  );

--- a/src/rules/checkConditionResult.js
+++ b/src/rules/checkConditionResult.js
@@ -9,6 +9,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+const ConditionNotMetError = require('./conditionNotMetError');
+
 const isConditionMet = (result, negate) => {
   return (result === true && !negate) || (result === false && negate);
 };
@@ -33,7 +35,7 @@ module.exports = ({
 
   if (!isConditionMet(conditionResult, negate)) {
     return Promise.reject(
-      new Error(
+      new ConditionNotMetError(
         `Condition "${conditionDisplayName}" from rule "${name}" not met.`
       )
     );

--- a/src/rules/conditionNotMetError.js
+++ b/src/rules/conditionNotMetError.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 Adobe. All rights reserved.
+Copyright 2021 Adobe. All rights reserved.
 This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
 of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -9,20 +9,19 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const process = (logsBucket, type, args) => {
-  logsBucket.push(
-    args
-      .map((m) => (typeof m !== 'string' ? JSON.stringify(m) : m))
-      .concat(type)
-  );
-};
+class ConditionNotMetError extends Error {
+  constructor(...params) {
+    // Pass remaining arguments (including vendor specific ones) to parent constructor
+    super(...params);
 
-module.exports = () => {
-  const logsBucket = [];
+    // Maintains proper stack trace for where our error was thrown (only available on V8)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, ConditionNotMetError);
+    }
 
-  return {
-    log: (...args) => process(logsBucket, 'log', args),
-    error: (...args) => process(logsBucket, 'error', args),
-    getJsonLogs: () => logsBucket
-  };
-};
+    this.name = 'ConditionNotMetError';
+    this.logMethod = 'log';
+  }
+}
+
+module.exports = ConditionNotMetError;

--- a/src/rules/createPromiseChain.js
+++ b/src/rules/createPromiseChain.js
@@ -1,0 +1,36 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const PROMISE_TIMEOUT = 30000;
+const normalizeDelegate = require('./normalizeDelegate');
+const addModuleToQueue = require('./addModuleToQueue');
+const logModuleErrorAndRethrow = require('./logModuleErrorAndRethrow');
+
+module.exports = ({ modules, resultFn, moduleProvider, utils }) => (
+  context
+) => {
+  let lastPromiseInChain = Promise.resolve(context);
+
+  if (modules) {
+    modules.forEach((condition) => {
+      lastPromiseInChain = addModuleToQueue(lastPromiseInChain, resultFn, {
+        timeout: PROMISE_TIMEOUT,
+        ...normalizeDelegate(condition, moduleProvider)
+      });
+    });
+  }
+
+  lastPromiseInChain = lastPromiseInChain.catch(
+    logModuleErrorAndRethrow({ utils })
+  );
+
+  return lastPromiseInChain;
+};

--- a/src/rules/logModuleErrorAndRethrow.js
+++ b/src/rules/logModuleErrorAndRethrow.js
@@ -10,6 +10,13 @@ governing permissions and limitations under the License.
 */
 
 module.exports = ({ utils: { logger } }) => (error) => {
-  logger.error(`${error.message}${error.stack ? ` \n ${error.stack}` : ''}`);
-  return Promise.reject();
+  const logMethod = error.logMethod || 'error';
+
+  logger[logMethod](
+    `${error.message}${
+      logMethod === 'error' && error.stack ? ` \n ${error.stack}` : ''
+    }`
+  );
+
+  return Promise.reject(error);
 };

--- a/src/rules/logRuleEnding.js
+++ b/src/rules/logRuleEnding.js
@@ -9,20 +9,15 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-const process = (logsBucket, type, args) => {
-  logsBucket.push(
-    args
-      .map((m) => (typeof m !== 'string' ? JSON.stringify(m) : m))
-      .concat(type)
-  );
-};
+module.exports = (context) => {
+  const {
+    arcAndUtils: {
+      utils: { getRule, logger }
+    }
+  } = context;
+  const { name } = getRule();
 
-module.exports = () => {
-  const logsBucket = [];
+  logger.log(`Execution of rule "${name}" is complete.`);
 
-  return {
-    log: (...args) => process(logsBucket, 'log', args),
-    error: (...args) => process(logsBucket, 'error', args),
-    getJsonLogs: () => logsBucket
-  };
+  return context;
 };

--- a/src/rules/logRuleStarting.js
+++ b/src/rules/logRuleStarting.js
@@ -17,7 +17,7 @@ module.exports = (context) => {
   } = context;
   const { name } = getRule();
 
-  logger.log(`Rule "${name}" is being executed.`);
+  logger.log(`Execution of rule "${name}" is starting.`);
 
   return context;
 };

--- a/src/rules/returnRuleResult.js
+++ b/src/rules/returnRuleResult.js
@@ -9,15 +9,17 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+const ConditionNotMetError = require('./conditionNotMetError');
+
 module.exports = (lastPromiseInQueue, { id: ruleId }, logger) =>
   lastPromiseInQueue
     .then(() => ({
       ruleId,
       status: 'success'
     }))
-    .catch(() => ({
+    .catch((e) => ({
       ruleId,
-      status: 'failed'
+      status: e instanceof ConditionNotMetError ? 'condition_not_met' : 'failed'
     }))
     .then((baseRuleResult) => {
       const ruleResult = baseRuleResult;


### PR DESCRIPTION
Change the way of how the rule components modules were added in a promise chain.

## Description

Before this change there was only one long promise chain for the conditions and actions from a rule. If the condition was returning a `false` result, there was a failed message logged for each action even if only the condition was technically failed.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have made any necessary test changes and all tests pass.
