### PR TITLE
PDCL-6370 Add getComponent method to utils sent to rule components an…

### DIFF
--- a/src/__tests__/createGetDataElementValue.test.js
+++ b/src/__tests__/createGetDataElementValue.test.js
@@ -260,4 +260,30 @@ describe('function returned by createGetDataElementValue', () => {
         );
       });
   });
+
+  test('provides access to getComponent method when it calls the data element module ', () => {
+    const moduleProvider = {
+      getModuleExports:
+        () =>
+        ({ utils: { getComponent } }) =>
+          getComponent()
+    };
+
+    const getDataElementValue = createGetDataElementValue(
+      {
+        settings: {},
+        id: 'DE123',
+        name: 'data element name'
+      },
+      { moduleProvider }
+    );
+
+    return getDataElementValue('testDataElement', defaultContext).then(
+      (dataElementValue) =>
+        expect(dataElementValue).toEqual({
+          id: 'DE123',
+          name: 'data element name'
+        })
+    );
+  });
 });

--- a/src/executeRules.js
+++ b/src/executeRules.js
@@ -34,6 +34,8 @@ module.exports = (
   const freezedInitialCallData = JSON.stringify(callData);
 
   rules.forEach((rule) => {
+    const { id, name } = rule;
+
     const logger = isDebugEnabled
       ? createNewLogger({ ruleId: rule.id })
       : fakeLogger;
@@ -41,7 +43,7 @@ module.exports = (
     const fetch = getRuleFetchFn(globalFetch, headersForSubrequests, logger);
 
     const utils = {
-      getRule: () => rule,
+      getRule: () => ({ id, name }),
       getBuildInfo: () => buildInfo,
       logger,
       fetch

--- a/src/rules/__tests__/executeDelegateModule.test.js
+++ b/src/rules/__tests__/executeDelegateModule.test.js
@@ -14,6 +14,24 @@ const executeDelegateModule = require('../executeDelegateModule');
 describe('executeDelegateModule', () => {
   test('executes the delegate module and adds the module output to the context', () => {
     const delegateConfig = {
+      getSettings: () => Promise.resolve(),
+      moduleExports: () => 'result'
+    };
+
+    return executeDelegateModule({
+      arcAndUtils: { arc: { someValue: 1 }, utils: {} },
+      delegateConfig
+    }).then((context) => {
+      expect(context).toStrictEqual({
+        moduleOutput: 'result',
+        delegateConfig,
+        arcAndUtils: { arc: { someValue: 1 }, utils: {} }
+      });
+    });
+  });
+
+  test('sends getSettings method when the delegate module is executed', () => {
+    const delegateConfig = {
       getSettings: (context) =>
         Promise.resolve({
           returnValue: context.arcAndUtils.arc.someValue
@@ -29,6 +47,26 @@ describe('executeDelegateModule', () => {
         moduleOutput: 1,
         delegateConfig,
         arcAndUtils: { arc: { someValue: 1 }, utils: {} }
+      });
+    });
+  });
+
+  test('sends getComponent method when the delegate module is executed', () => {
+    const delegateConfig = {
+      id: 'RC123',
+      name: 'Delegate name',
+      getSettings: () => Promise.resolve(1),
+      moduleExports: ({ utils: { getComponent } }) => getComponent()
+    };
+
+    return executeDelegateModule({
+      arcAndUtils: {},
+      delegateConfig
+    }).then((context) => {
+      expect(context).toStrictEqual({
+        moduleOutput: { id: 'RC123', name: 'Delegate name' },
+        delegateConfig,
+        arcAndUtils: {}
       });
     });
   });

--- a/src/rules/executeDelegateModule.js
+++ b/src/rules/executeDelegateModule.js
@@ -12,7 +12,7 @@ governing permissions and limitations under the License.
 module.exports = (context) => {
   const { arcAndUtils, delegateConfig } = context;
   const { utils } = arcAndUtils;
-  const { getSettings, moduleExports } = delegateConfig;
+  const { getSettings, moduleExports, id, name } = delegateConfig;
 
   return getSettings(context)
     .then((settings) =>
@@ -20,7 +20,8 @@ module.exports = (context) => {
         ...arcAndUtils,
         utils: {
           ...utils,
-          getSettings: () => settings
+          getSettings: () => settings,
+          getComponent: () => ({ id, name })
         }
       })
     )


### PR DESCRIPTION
…d data elements.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Give a developer a mean to get the and id and the name of a data element or of a rule component. The utils object that is made available to developers will contain a getComponent method.

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-6370

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which does not add functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html) or I'm an Adobe employee.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have made any necessary test changes and all tests pass.
